### PR TITLE
Implement #find for LDF Based Authorities

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,9 @@ Metric/BlockLength:
 # we accept `expect(subject).to receive`
 RSpec/MessageSpies:
   Enabled: false
+
+# we accept specs in fakes, mocks, &c...
+RSpec/FilePath:
+  Exclude: 
+    - 'spec/support/**/*'
+

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ gem 'pry' unless ENV['CI']
 
 # develop on qa master
 gem 'qa', github: 'projecthydra-labs/questioning_authority', branch: 'master'
+
+gem 'ld_cache_fragment',
+    github: 'ActiveTriples/linked-data-fragments',
+    branch: 'feature/rack-server'

--- a/config/ldf.yml
+++ b/config/ldf.yml
@@ -1,0 +1,15 @@
+development:
+  uri_endpoint: 'http://localhost:3000/{?subject}'
+  uri_root: 'http://localhost:3000/#dataset'
+  cache_backend:
+    provider: 'repository'
+test: &TEST_
+  uri_endpoint: 'http://localhost:3000/{?subject}'
+  uri_root: 'http://localhost:3000/#dataset'
+  cache_backend:
+    provider: 'repository'
+production:
+  uri_endpoint: 'http://localhost:3000/{?subject}'
+  uri_root: 'http://localhost:3000/#dataset'
+  cache_backend:
+    provider: 'repository'

--- a/lib/qa/ldf.rb
+++ b/lib/qa/ldf.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 require 'qa/ldf/version'
 
-require 'qa/ldf/authority'
-require 'qa/ldf/configuration'
+require 'qa/ldf/client'
 require 'qa/ldf/json_mapper'
+require 'qa/ldf/configuration'
+
+require 'qa/ldf/authority'
 
 ##
 # @see https://github.com/projecthydra-labs/questioning_authority Qa

--- a/lib/qa/ldf.rb
+++ b/lib/qa/ldf.rb
@@ -3,6 +3,7 @@ require 'qa/ldf/version'
 
 require 'qa/ldf/authority'
 require 'qa/ldf/configuration'
+require 'qa/ldf/json_mapper'
 
 ##
 # @see https://github.com/projecthydra-labs/questioning_authority Qa

--- a/lib/qa/ldf.rb
+++ b/lib/qa/ldf.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
-require 'qa/ldf/configuration'
 require 'qa/ldf/version'
+
+require 'qa/ldf/authority'
+require 'qa/ldf/configuration'
 
 ##
 # @see https://github.com/projecthydra-labs/questioning_authority Qa

--- a/lib/qa/ldf/authority.rb
+++ b/lib/qa/ldf/authority.rb
@@ -4,7 +4,12 @@ require 'qa/authorities'
 module Qa
   module LDF
     ##
-    # A Linked Data Fragments-based authority.
+    # A Linked Data Fragments-based authority. Access linked data resources
+    # through a caching server.
+    #
+    # @todo Configure dataset for individual authority lookup.
+    #
+    # @see LinkedDataFragments::CacheServer
     class Authority < Qa::Authorities::Base
       ##
       # The default linked data fragments client
@@ -19,7 +24,7 @@ module Qa
       #   @return [Client]
       # @!attribute [rw] mapper
       #   @return [Mapper]
-      attr_accessor :client, :mapper
+      attr_writer :client, :mapper
 
       ##
       # @see Qa::Authorities::Base#all
@@ -28,7 +33,14 @@ module Qa
       end
 
       ##
+      # Retrieves the given resource's JSON respresentation from the cache
+      # server.
+      #
+      # The resource is retrieved through the client given by `#client`, and
+      # mapped to JSON using `#mapper`.
+      #
       # @see Qa::Authorities::Base#find
+      # @see Qa::LDF::Client#get
       def find(id)
         graph = client.get(uri: id)
 

--- a/lib/qa/ldf/authority.rb
+++ b/lib/qa/ldf/authority.rb
@@ -7,6 +7,21 @@ module Qa
     # A Linked Data Fragments-based authority.
     class Authority < Qa::Authorities::Base
       ##
+      # The default linked data fragments client
+      DEFAULT_CLIENT = Qa::LDF::Client
+
+      ##
+      # The default mapper
+      DEFAULT_MAPPER = Qa::LDF::JsonMapper
+
+      ##
+      # @!attribute [rw] client
+      #   @return [Client]
+      # @!attribute [rw] mapper
+      #   @return [Mapper]
+      attr_accessor :client, :mapper
+
+      ##
       # @see Qa::Authorities::Base#all
       def all
         []
@@ -15,9 +30,9 @@ module Qa
       ##
       # @see Qa::Authorities::Base#find
       def find(id)
-        graph = RDF::Graph.load(id)
+        graph = client.get(uri: id)
 
-        json_mapper.map_resource(id, graph)
+        mapper.map_resource(id, graph)
       end
 
       ##
@@ -31,9 +46,15 @@ module Qa
       end
 
       ##
-      # @return [JSON_Mapper]
-      def json_mapper
-        @json_mapper ||= JsonMapper.new
+      # @return [JsonMapper]
+      def mapper
+        @mapper ||= DEFAULT_MAPPER.new
+      end
+
+      ##
+      # @return [Qa::LDF::Client]
+      def client
+        @client ||= DEFAULT_CLIENT.new
       end
     end
   end

--- a/lib/qa/ldf/authority.rb
+++ b/lib/qa/ldf/authority.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'qa/authorities'
 
 module Qa
@@ -15,8 +14,10 @@ module Qa
 
       ##
       # @see Qa::Authorities::Base#find
-      def find(_id)
-        {}
+      def find(id)
+        graph = RDF::Graph.load(id)
+
+        json_mapper.map_resource(id, graph)
       end
 
       ##
@@ -27,6 +28,12 @@ module Qa
       # @return [Hash<Symbol, String>] the response as a JSON friendly hash
       def search(_query)
         {}
+      end
+
+      ##
+      # @return [JSON_Mapper]
+      def json_mapper
+        @json_mapper ||= JsonMapper.new
       end
     end
   end

--- a/lib/qa/ldf/authority.rb
+++ b/lib/qa/ldf/authority.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'qa/authorities'
+
+module Qa
+  module LDF
+    ##
+    # A Linked Data Fragments-based authority.
+    class Authority < Qa::Authorities::Base
+      ##
+      # @see Qa::Authorities::Base#all
+      def all
+        []
+      end
+
+      ##
+      # @see Qa::Authorities::Base#find
+      def find(_id)
+        {}
+      end
+
+      ##
+      # Search the vocabulary
+      #
+      # @param _query [String] the query string
+      #
+      # @return [Hash<Symbol, String>] the response as a JSON friendly hash
+      def search(_query)
+        {}
+      end
+    end
+  end
+end

--- a/lib/qa/ldf/client.rb
+++ b/lib/qa/ldf/client.rb
@@ -17,7 +17,16 @@ module Qa
       # @see RDF::Mutable#load
       # @see RDF::LinkedDataFragments::CacheServer
       def get(uri:)
-        RDF::Graph.load(uri)
+        RDF::Graph.load(cache_uri(uri))
+      end
+
+      ##
+      # @param uri [String] a URI-like string
+      # @return [RDF::URI]
+      def cache_uri(uri)
+        cache_uri = RDF::URI(Qa::LDF::Configuration.instance[:endpoint])
+        cache_uri.query = "subject=#{uri}"
+        cache_uri
       end
     end
   end

--- a/lib/qa/ldf/client.rb
+++ b/lib/qa/ldf/client.rb
@@ -1,0 +1,24 @@
+module Qa
+  module LDF
+    ##
+    # A client for the LD cache server
+    class Client
+      ##
+      # @yield [Client] yields self to a block if given
+      def initialize
+        yield self if block_given?
+      end
+
+      ##
+      # @param uri [String] a URI-like string
+      #
+      # @return [RDF::Graph]
+      #
+      # @see RDF::Mutable#load
+      # @see RDF::LinkedDataFragments::CacheServer
+      def get(uri:)
+        RDF::Graph.load(uri)
+      end
+    end
+  end
+end

--- a/lib/qa/ldf/configuration.rb
+++ b/lib/qa/ldf/configuration.rb
@@ -54,6 +54,14 @@ module Qa
         yield self if block_given?
         self
       end
+
+      ##
+      # Empties all configuration options
+      #
+      # @return opts [Hash]
+      def reset!
+        @options = {}
+      end
     end
   end
 end

--- a/lib/qa/ldf/json_mapper.rb
+++ b/lib/qa/ldf/json_mapper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Qa
+  module LDF
+    ##
+    # A customizable mapper from {RDF::Graph}s to JSON-like hashes for use in
+    # Questioning Authority.
+    #
+    # @todo: Add configuration
+    #
+    # @example maps a graphs to QA JSON objects.
+    #   mapper = JsonMapper.new
+    #
+    #   uri   = 'http://id.loc.gov/authorities/subjects/sh2004002557'
+    #   graph = RDF::Graph.load(uri)
+    #
+    #   mapper.map_resource(uri, graph)
+    #   # => { id:    'http://id.loc.gov/authorities/subjects/sh2004002557',
+    #   #      label: 'Marble Island (Nunavut)' }
+    #
+    class JsonMapper
+      ##
+      # @param uri   [String] a URI-like string
+      # @param graph [RDF::Queryable]
+      #
+      # @return [Hash<Symbol, String>]
+      def map_resource(uri, graph)
+        labels =
+          graph.query(subject:   RDF::URI.intern(uri),
+                      predicate: RDF::Vocab::SKOS.prefLabel).objects
+
+        { id: uri, label: labels.first.to_s }
+      end
+    end
+  end
+end

--- a/qa-ldf.gemspec
+++ b/qa-ldf.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'qa', '~> 0.11.0'
 
-  spec.add_development_dependency 'sham_rack'
+  spec.add_development_dependency 'guard',             '~> 2.14'
   spec.add_development_dependency 'ld_cache_fragment', '~> 0.1.0'
-
-  spec.add_development_dependency 'rake',          '~> 12.0'
-  spec.add_development_dependency 'rspec',         '~> 3.5.0'
-  spec.add_development_dependency 'rubocop-rspec', '1.10.0'
-  spec.add_development_dependency 'guard',         '~> 2.14'
-  spec.add_development_dependency 'yard',          '~> 0'
+  spec.add_development_dependency 'rake',              '~> 12.0'
+  spec.add_development_dependency 'rspec',             '~> 3.5.0'
+  spec.add_development_dependency 'rubocop-rspec',     '1.10.0'
+  spec.add_development_dependency 'sham_rack',         '~> 1.4.0'
+  spec.add_development_dependency 'webmock',           '~> 2.3.2'
+  spec.add_development_dependency 'yard',              '~> 0'
 end

--- a/qa-ldf.gemspec
+++ b/qa-ldf.gemspec
@@ -22,6 +22,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'qa', '~> 0.11.0'
 
+  spec.add_development_dependency 'sham_rack'
+  spec.add_development_dependency 'ld_cache_fragment', '~> 0.1.0'
+
   spec.add_development_dependency 'rake',          '~> 12.0'
   spec.add_development_dependency 'rspec',         '~> 3.5.0'
   spec.add_development_dependency 'rubocop-rspec', '1.10.0'

--- a/spec/qa/ldf/authority_spec.rb
+++ b/spec/qa/ldf/authority_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Qa::LDF::Authority do
+  include_context 'with cache server'
+
   subject(:authority) { described_class.new }
 
   let(:id) { 'Moomin' }

--- a/spec/qa/ldf/authority_spec.rb
+++ b/spec/qa/ldf/authority_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
+# @todo: pick a good way to stub graph loading behavior; these tests depends on
+#   the external service. The best choice is probably to stub and contract test
+#   the cache server.
 describe Qa::LDF::Authority do
   include_context 'with cache server'
 
   subject(:authority) { described_class.new }
 
-  let(:id) { 'Moomin' }
+  let(:subject_uri)  { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+  let(:endpoint_uri) { RDF::URI.intern(server_endpoint) }
 
   describe '#all' do
     it 'is enumerable' do
@@ -16,7 +20,18 @@ describe Qa::LDF::Authority do
   end
 
   describe '#find' do
-    it 'returns a JSON-like hash'
+    it 'returns a JSON-like hash' do
+      expect(authority.find(subject_uri)).to be_a Hash
+    end
+
+    it 'includes an id' do
+      expect(authority.find(subject_uri)[:id]).to eq subject_uri
+    end
+
+    it 'includes a label' do
+      expect(authority.find(subject_uri)[:label])
+        .to eq 'Marble Island (Nunavut)'
+    end
   end
 
   describe '#search' do

--- a/spec/qa/ldf/authority_spec.rb
+++ b/spec/qa/ldf/authority_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Qa::LDF::Authority do
+  subject(:authority) { described_class.new }
+
+  let(:id) { 'Moomin' }
+
+  describe '#all' do
+    it 'is enumerable' do
+      expect(authority.all).to respond_to :each
+    end
+
+    it 'enumerates the vocabulary'
+  end
+
+  describe '#find' do
+    it 'returns a JSON-like hash'
+  end
+
+  describe '#search' do
+    it 'searches the vocabulary'
+  end
+end

--- a/spec/qa/ldf/authority_spec.rb
+++ b/spec/qa/ldf/authority_spec.rb
@@ -1,15 +1,24 @@
 require 'spec_helper'
 
-# @todo: pick a good way to stub graph loading behavior; these tests depends on
-#   the external service. The best choice is probably to stub and contract test
-#   the cache server.
 describe Qa::LDF::Authority do
-  include_context 'with cache server'
+  subject(:authority) do
+    auth = described_class.new
 
-  subject(:authority) { described_class.new }
+    auth.client = FakeClient.new do |client|
+      client.graph = RDF::Graph.new << statement
+      client.label = label
+    end
 
-  let(:subject_uri)  { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+    auth
+  end
+
+  let(:label)        { 'Marble Island (Nunavut)' }
   let(:endpoint_uri) { RDF::URI.intern(server_endpoint) }
+  let(:subject_uri)  { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+
+  let(:statement) do
+    [RDF::URI(subject_uri), RDF::Vocab::SKOS.prefLabel, RDF::Literal(label)]
+  end
 
   describe '#all' do
     it 'is enumerable' do
@@ -29,8 +38,7 @@ describe Qa::LDF::Authority do
     end
 
     it 'includes a label' do
-      expect(authority.find(subject_uri)[:label])
-        .to eq 'Marble Island (Nunavut)'
+      expect(authority.find(subject_uri)[:label]).to eq label
     end
   end
 

--- a/spec/qa/ldf/client_spec.rb
+++ b/spec/qa/ldf/client_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+##
+# @todo: Stub LDF behavior at this point. Add integration/contract tests for
+#   this interface.
+describe Qa::LDF::Client do
+  subject(:client) { described_class.new }
+
+  let(:uri) { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+
+  include_context 'with cache server'
+  it_behaves_like 'an ld cache client'
+end

--- a/spec/qa/ldf/client_spec.rb
+++ b/spec/qa/ldf/client_spec.rb
@@ -5,7 +5,16 @@ require 'spec_helper'
 describe Qa::LDF::Client do
   subject(:client) { described_class.new }
 
-  let(:uri) { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+  let(:uri)        { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+  let(:graph_stub) { RDF::Graph.new << [RDF::URI(uri), RDF.type, RDF.Property] }
+
+  before do
+    stub_request(:get, uri)
+      .to_return(status:  200,
+                 body:    graph_stub.dump(:ntriples),
+                 headers: { 'Content-Type' =>
+                            RDF::Format.for(:ntriples).content_type })
+  end
 
   include_context 'with cache server'
   it_behaves_like 'an ld cache client'

--- a/spec/qa/ldf/configuration_spec.rb
+++ b/spec/qa/ldf/configuration_spec.rb
@@ -5,6 +5,7 @@ describe Qa::LDF::Configuration do
 
   shared_context 'with configuration' do
     before { config.configure!(**options) }
+    after  { config.reset! }
 
     let(:options) do
       { option: :moomin }
@@ -63,6 +64,14 @@ describe Qa::LDF::Configuration do
 
     it 'enumerates the options hash' do
       expect(config.each).to contain_exactly(*options.each)
+    end
+  end
+
+  describe '#reset!' do
+    include_context 'with configuration'
+
+    it 'resets options hash' do
+      expect { config.reset! }.to change { config.to_a }.to be_empty
     end
   end
 

--- a/spec/qa/ldf/json_mapper_spec.rb
+++ b/spec/qa/ldf/json_mapper_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Qa::LDF::JsonMapper do
+  subject(:mapper) { described_class.new }
+
+  let(:uri)    { 'http://example.com/moomin' }
+  let(:label)  { RDF::Literal('Moomin') }
+
+  let(:graph) do
+    RDF::Graph.new << [RDF::URI(uri), RDF::Vocab::SKOS.prefLabel, label]
+  end
+
+  describe '#map_resource' do
+    it 'maps with an id' do
+      expect(mapper.map_resource(uri, graph)[:id]).to eq uri
+    end
+
+    it 'maps with a label' do
+      expect(mapper.map_resource(uri, graph)[:label]).to eq label
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 Bundler.setup
 
 require 'pry' unless ENV['CI']
+require 'webmock/rspec'
 
 require 'qa/ldf'
 

--- a/spec/support/cache_server.rb
+++ b/spec/support/cache_server.rb
@@ -4,9 +4,22 @@ require 'linked_data_fragments/cache_server'
 require 'linked_data_fragments/repository'
 
 shared_context 'with cache server' do
+  let(:server_endpoint) { 'http://ldcache.example.com/' }
+
   before(:context) do
+    server_endpoint = 'ldcache.example.com'
+
     ShamRack
-      .at('ldcache.example.com')
+      .at(server_endpoint)
       .mount(LinkedDataFragments::CacheServer::APPLICATION)
+
+    Qa::LDF.configure! do |config|
+      config[:endpoint] = "http://#{server_endpoint}"
+    end
+  end
+
+  after(:context) do
+    ShamRack.reset
+    Qa::LDF::Configuration.instance.reset!
   end
 end

--- a/spec/support/cache_server.rb
+++ b/spec/support/cache_server.rb
@@ -1,0 +1,12 @@
+require 'sham_rack'
+
+require 'linked_data_fragments/cache_server'
+require 'linked_data_fragments/repository'
+
+shared_context 'with cache server' do
+  before(:context) do
+    ShamRack
+      .at('ldcache.example.com')
+      .mount(LinkedDataFragments::CacheServer::APPLICATION)
+  end
+end

--- a/spec/support/fake_client.rb
+++ b/spec/support/fake_client.rb
@@ -1,0 +1,29 @@
+require 'support/shared_examples/ld_cache_client'
+
+require 'rdf'
+require 'rdf/vocab/skos'
+
+##
+# A fake version of `Qa::LDF::Client`.
+class FakeClient
+  attr_accessor :label, :graph
+
+  def initialize
+    yield self if block_given?
+  end
+
+  def get(uri:)
+    graph ||= RDF::Graph.new
+    graph =
+      graph.dup <<
+      [RDF::URI(uri), RDF::Vocab::SKOS.prefLabel, label || 'moomin']
+    graph
+  end
+end
+
+describe FakeClient do
+  subject(:client) { described_class.new }
+
+  let(:uri) { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+  it_behaves_like 'an ld cache client'
+end

--- a/spec/support/shared_examples/ld_cache_client.rb
+++ b/spec/support/shared_examples/ld_cache_client.rb
@@ -1,0 +1,22 @@
+shared_examples 'an ld cache client' do
+  before do
+    raise 'Must define `uri` via `let(:uri)` to use examples' unless
+      defined?(uri)
+    raise 'Must define `client` via `let(:client)` to use examples' unless
+      defined?(client)
+  end
+
+  describe '#get' do
+    it 'returns an RDF::Enumerable' do
+      expect(client.get(uri: uri)).to respond_to :each_statement
+    end
+
+    it 'returns an RDF::Queryable' do
+      expect(client.get(uri: uri)).to respond_to :query
+    end
+
+    it 'gives a graph with the subject' do
+      expect(client.get(uri: uri)).to have_subject RDF::URI(uri)
+    end
+  end
+end


### PR DESCRIPTION
This is one third of the basic Qa::LDF interface. The other two parts are `#search` and `#all`.

Implements a basic authority outline, provides utilities for set up/tear down of a caching service for the test suite with Rack.

Mapping from RDF to JSON is provided via a `Mapper` interface, which is hard coded for the time being.

A client interface creates a clean break between the QA side and the cache server.