### PR TITLE
Add LCNames Authority

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,9 @@ AllCops:
   DisplayCopNames: true
 
 Metric/BlockLength:
-  Exclude: 
+  Exclude:
     - 'spec/**/*'
+    - 'lib/qa/ldf/spec/**/*'
 
 # we accept `expect(subject).to receive`
 RSpec/MessageSpies:
@@ -13,6 +14,7 @@ RSpec/MessageSpies:
 
 # we accept specs in fakes, mocks, &c...
 RSpec/FilePath:
-  Exclude: 
+  Exclude:
+    - 'spec/contracts/**/*'
     - 'spec/support/**/*'
-
+    - 'spec/qa/ldf/authorities/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,4 @@ gem 'qa', github: 'projecthydra-labs/questioning_authority', branch: 'master'
 
 gem 'ld_cache_fragment',
     github: 'ActiveTriples/linked-data-fragments',
-    branch: 'feature/rack-server'
+    branch: 'feature/multi-dataset'

--- a/Guardfile
+++ b/Guardfile
@@ -8,9 +8,11 @@ guard :rspec, cmd: 'bundle exec rspec' do
 
   # RSpec files
   rspec = dsl.rspec
-  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_helper)  { rspec.spec_dir }
   watch(rspec.spec_support) { rspec.spec_dir }
   watch(rspec.spec_files)
+
+  watch(%r{lib\/qa\/ldf\/spec\/.*\.rb}) { rspec.spec_dir }
 
   # Ruby files
   ruby = dsl.ruby

--- a/lib/qa/ldf.rb
+++ b/lib/qa/ldf.rb
@@ -6,6 +6,7 @@ require 'qa/ldf/json_mapper'
 require 'qa/ldf/configuration'
 
 require 'qa/ldf/authority'
+require 'qa/ldf/authorities'
 
 ##
 # @see https://github.com/projecthydra-labs/questioning_authority Qa

--- a/lib/qa/ldf/authorities.rb
+++ b/lib/qa/ldf/authorities.rb
@@ -1,0 +1,1 @@
+require 'qa/ldf/authorities/lc_names'

--- a/lib/qa/ldf/authorities/lc_names.rb
+++ b/lib/qa/ldf/authorities/lc_names.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Qa
+  module LDF
+    ##
+    # A caching LCSH authority.
+    #
+    # @note This uses the search logic from the basic Loc authority that ships
+    #   with QA: `Qa::Authorities::Loc::GenericAuthority`.
+    #
+    # @see LinkedDataFragments::CacheServer
+    class LCNames < Authority
+      DEFAULT_DATASET_NAME = :lcnames
+      LC_SUBAUTHORITY      = 'names'.freeze
+
+      ##
+      # Uses the LC names subauthority as the search provider
+      def search_service
+        @search_service ||=
+          Qa::Authorities::Loc.subauthority_for(LC_SUBAUTHORITY)
+      end
+    end
+  end
+end

--- a/lib/qa/ldf/authority.rb
+++ b/lib/qa/ldf/authority.rb
@@ -26,8 +26,7 @@ module Qa
       #   @return [Symbol] A dataset name (e.g. :lcsh)
       # @!attribute [rw] mapper
       #   @return [Mapper]
-      attr_accessor :name
-      attr_writer :client, :mapper
+      attr_writer :client, :dataset, :mapper
 
       ##
       # @see Qa::Authorities::Base#all
@@ -45,7 +44,7 @@ module Qa
       # @see Qa::Authorities::Base#find
       # @see Qa::LDF::Client#get
       def find(id)
-        graph = client.get(uri: id)
+        graph = client.get(uri: id, dataset: dataset)
 
         mapper.map_resource(id, graph)
       end
@@ -58,6 +57,12 @@ module Qa
       # @return [Hash<Symbol, String>] the response as a JSON friendly hash
       def search(_query)
         {}
+      end
+
+      ##
+      # @return [Symbol]
+      def dataset
+        @dataset ||= :''
       end
 
       ##

--- a/lib/qa/ldf/authority.rb
+++ b/lib/qa/ldf/authority.rb
@@ -22,8 +22,11 @@ module Qa
       ##
       # @!attribute [rw] client
       #   @return [Client]
+      # @!attribute [rw] dataset
+      #   @return [Symbol] A dataset name (e.g. :lcsh)
       # @!attribute [rw] mapper
       #   @return [Mapper]
+      attr_accessor :name
       attr_writer :client, :mapper
 
       ##

--- a/lib/qa/ldf/client.rb
+++ b/lib/qa/ldf/client.rb
@@ -10,22 +10,28 @@ module Qa
       end
 
       ##
-      # @param uri [String] a URI-like string
+      # @param uri     [String] a URI-like string
+      # @param dataset [Symbol]
       #
       # @return [RDF::Graph]
       #
       # @see RDF::Mutable#load
       # @see RDF::LinkedDataFragments::CacheServer
-      def get(uri:)
-        RDF::Graph.load(cache_uri(uri))
+      def get(uri:, dataset: :'')
+        RDF::Graph.load(cache_uri(uri, dataset))
       end
 
+      private
+
       ##
-      # @param uri [String] a URI-like string
+      # @param uri     [String] a URI-like string
+      # @param dataset [Symbol]
+      #
       # @return [RDF::URI]
-      def cache_uri(uri)
+      def cache_uri(uri, dataset)
         cache_uri = RDF::URI(Qa::LDF::Configuration.instance[:endpoint])
         cache_uri.query = "subject=#{uri}"
+        cache_uri = cache_uri / 'dataset' / dataset unless dataset.empty?
         cache_uri
       end
     end

--- a/lib/qa/ldf/empty_search_service.rb
+++ b/lib/qa/ldf/empty_search_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Qa
+  module LDF
+    ##
+    # A search service that always returns no results.
+    #
+    # @example
+    #   EmptySearchService.new.search('any query') # => {}
+    #
+    class EmptySearchService
+      ##
+      # @see Qa::Authority::Base#search
+      def search(_query)
+        []
+      end
+    end
+  end
+end

--- a/lib/qa/ldf/spec.rb
+++ b/lib/qa/ldf/spec.rb
@@ -1,0 +1,2 @@
+require 'qa/ldf/spec/authority'
+require 'qa/ldf/spec/search_service'

--- a/lib/qa/ldf/spec/authority.rb
+++ b/lib/qa/ldf/spec/authority.rb
@@ -1,0 +1,105 @@
+shared_examples 'an ldf authority' do
+  before do
+    unless defined?(authority)
+      raise ArgumentError,
+            "#{authority} must be defined with `let(:authority)` before " \
+            'using LDF::Authority shared examples.'
+    end
+
+    unless defined?(ldf_uri)
+      raise ArgumentError,
+            "#{ldf_uri} must be defined with `let(:ldf_uri)` before using " \
+            'LDF::Authority shared examples.'
+    end
+    unless defined?(ldf_label)
+      raise ArgumentError,
+            "#{ldf_label} must be defined with `let(:ldf_label)` before " \
+            'using LDF::Authority shared examples.'
+    end
+  end
+
+  describe '#all' do
+    it 'is enumerable' do
+      expect(authority.all).to respond_to :each
+    end
+
+    it 'enumerates the vocabulary'
+  end
+
+  describe '#client' do
+    it 'defaults to an instance of DEFAULT_CLIENT' do
+      expect(described_class.new.client)
+        .to be_a described_class::DEFAULT_CLIENT
+    end
+
+    it 'sets to other instances' do
+      client = described_class::DEFAULT_CLIENT.new
+
+      expect { authority.client = client }
+        .to change { authority.client }
+        .to equal client
+    end
+  end
+
+  describe '#dataset' do
+    it 'defaults DEFAULT_DATASET_NAME' do
+      expect(described_class.new.dataset)
+        .to eq described_class::DEFAULT_DATASET_NAME
+    end
+
+    it 'sets to other symbols' do
+      dataset_name = :new_name
+
+      expect { authority.dataset = dataset_name }
+        .to change { authority.dataset }
+        .to eq dataset_name
+    end
+  end
+
+  describe '#find' do
+    it 'finds a uri' do
+      expect(authority.find(ldf_uri))
+        .to include id: ldf_uri.to_s, label: ldf_label
+    end
+
+    it 'maps to a json-friendly hash' do
+      expect { JSON.generate(authority.find(ldf_uri)) }.not_to raise_error
+    end
+  end
+
+  describe '#mapper' do
+    it 'defaults to an instance of DEFAULT_MAPPER' do
+      expect(described_class.new.mapper)
+        .to be_a described_class::DEFAULT_MAPPER
+    end
+
+    it 'sets to other instances' do
+      mapper = described_class::DEFAULT_MAPPER.new
+
+      expect { authority.mapper = mapper }
+        .to change { authority.mapper }
+        .to equal mapper
+    end
+  end
+
+  describe '#search' do
+    let(:query)    { 'My Fake Query' }
+    let(:response) { { my: 'response' } }
+
+    it 'gives an array' do
+      expect(authority.search('tove')).to respond_to :to_ary
+    end
+
+    it 'gives a json-friendly array' do
+      expect { JSON.generate(authority.search('tove')) }.not_to raise_error
+    end
+
+    it 'searches the search service' do
+      authority.search_service = FakeSearchService.new do |service|
+        service.queries[query] = response
+      end
+
+      expect(authority.search(query)).to eq response
+    end
+  end
+end

--- a/lib/qa/ldf/spec/search_service.rb
+++ b/lib/qa/ldf/spec/search_service.rb
@@ -1,0 +1,30 @@
+shared_examples 'an ldf search service' do
+  before do
+    unless defined?(search_service)
+      raise ArgumentError,
+            "#{search_service} must be defined with `let(:search_service)` " \
+            'before using LDF::Authority shared examples.'
+    end
+
+    unless defined?(searches)
+      warn 'You did not provide any valid searches to the ldf search service ' \
+           "shared examples for #{described_class}. Use `let(:searches) = " \
+           '{"query" => {key: "value"} to configure searches to test'
+    end
+  end
+
+  describe '#search' do
+    it 'gives a json-friendly array' do
+      JSON.generate(search_service.search('tove'))
+      expect { JSON.generate(search_service.search('tove')) }.not_to raise_error
+    end
+
+    it 'responds to searches' do
+      if defined?(searches)
+        searches.each do |query, response|
+          expect(search_service.search(query)).to eq response
+        end
+      end
+    end
+  end
+end

--- a/spec/contracts/qa_loc_as_search_service_spec.rb
+++ b/spec/contracts/qa_loc_as_search_service_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'qa/authorities/loc'
+
+# We need to guarantee `Loc.subauthority_for('names')` behaves like a search
+# service
+describe Qa::Authorities::Loc do
+  subject(:search_service) { described_class.subauthority_for('names') }
+  before do
+    # an empty response for 'tove'
+    stub_request(:get, 'http://id.loc.gov/search/?format=json&'\
+                       'q=tove&q=cs:http://id.loc.gov/authorities/names')
+      .with(headers: { 'Accept' => 'application/json' })
+      .to_return(status: 200, body: '[]', headers: {})
+
+    # real responses from fixtures
+    search_config.each do |search|
+      stub_request(:get, 'http://id.loc.gov/search/?format=json' \
+                         "&q=#{search[:query]}&q=cs:" \
+                         'http://id.loc.gov/authorities/names')
+        .with(headers: { 'Accept' => 'application/json' })
+        .to_return(status: 200, body: search[:body], headers: {})
+    end
+  end
+
+  let(:search_config) do
+    [
+      { query: 'moomin', body: '[]', result: [] }, # an empty body
+    ]
+  end
+
+  let(:searches) do
+    search_config.each_with_object({}) do |search, hsh|
+      hsh[search[:query]] = search[:result]
+    end
+  end
+
+  it_behaves_like 'an ldf search service'
+end

--- a/spec/qa/ldf/authorities/lc_names_spec.rb
+++ b/spec/qa/ldf/authorities/lc_names_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Qa::LDF::LCNames do
+  it_behaves_like 'an ldf authority'
+
+  subject(:authority) do
+    auth = described_class.new
+
+    auth.client = FakeClient.new do |client|
+      client.graph = RDF::Graph.new
+      client.graph.insert(*statements)
+      client.label = ldf_label
+    end
+
+    auth
+  end
+
+  let(:ldf_label)    { 'Marble Island (Nunavut)' }
+  let(:ldf_uri)      { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+
+  let(:statements) do
+    [RDF::Statement(RDF::URI(ldf_uri),
+                    RDF::Vocab::SKOS.prefLabel,
+                    RDF::Literal(ldf_label))]
+  end
+
+  before do
+    # mock empty responses for all queries;
+    # see spec/contracts/qa_loc_as_search_service.rb for lc search service tests
+    stub_request(:get, 'http://id.loc.gov/search/?format=json&' \
+                       'q=cs:http://id.loc.gov/authorities/names')
+      .with(headers: { 'Accept' => 'application/json' })
+      .to_return(status: 200, body: '[]', headers: {})
+  end
+
+  describe '#search_service' do
+    it 'hits the upstream loc endpoint by default' do
+      query = 'a query'
+      url   = 'http://id.loc.gov/search/?format=json' \
+              "&q=#{query}&q=cs:http://id.loc.gov/authorities/names"
+      expect(a_request(:get, url))
+
+      authority.search_service.search(query)
+    end
+  end
+
+  describe '#dataset' do
+    it 'defaults to :lcnames' do
+      expect(described_class.new.dataset).to eq :lcnames
+    end
+  end
+end

--- a/spec/qa/ldf/authority_spec.rb
+++ b/spec/qa/ldf/authority_spec.rb
@@ -1,78 +1,29 @@
 require 'spec_helper'
 
 describe Qa::LDF::Authority do
+  it_behaves_like 'an ldf authority'
+
   subject(:authority) do
     auth = described_class.new
 
     auth.client = FakeClient.new do |client|
       client.graph = RDF::Graph.new << statement
-      client.label = label
+      client.label = ldf_label
     end
 
     auth
   end
 
-  let(:label)        { 'Marble Island (Nunavut)' }
-  let(:endpoint_uri) { RDF::URI.intern(server_endpoint) }
-  let(:subject_uri)  { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
+  let(:ldf_label)    { 'Marble Island (Nunavut)' }
+  let(:ldf_uri)      { 'http://id.loc.gov/authorities/subjects/sh2004002557' }
 
   let(:statement) do
-    [RDF::URI(subject_uri), RDF::Vocab::SKOS.prefLabel, RDF::Literal(label)]
-  end
-
-  describe '#all' do
-    it 'is enumerable' do
-      expect(authority.all).to respond_to :each
-    end
-
-    it 'enumerates the vocabulary'
-  end
-
-  describe '#client' do
-    it 'defaults to an instance of DEFAULT_CLIENT' do
-      expect(described_class.new.client)
-        .to be_a described_class::DEFAULT_CLIENT
-    end
-
-    it 'sets to other instances' do
-      client = described_class::DEFAULT_CLIENT.new
-
-      expect { authority.client = client }
-        .to change { authority.client }
-        .to equal client
-    end
+    [RDF::URI(ldf_uri), RDF::Vocab::SKOS.prefLabel, RDF::Literal(ldf_label)]
   end
 
   describe '#dataset' do
     it 'defaults an empty string symbol' do
       expect(described_class.new.dataset).to eq :''
     end
-
-    it 'sets to other symbols' do
-      dataset_name = :lcsh
-
-      expect { authority.dataset = dataset_name }
-        .to change { authority.dataset }
-        .to eq dataset_name
-    end
-  end
-
-  describe '#mapper' do
-    it 'defaults to an instance of DEFAULT_MAPPER' do
-      expect(described_class.new.mapper)
-        .to be_a described_class::DEFAULT_MAPPER
-    end
-
-    it 'sets to other instances' do
-      mapper = described_class::DEFAULT_MAPPER.new
-
-      expect { authority.mapper = mapper }
-        .to change { authority.mapper }
-        .to equal mapper
-    end
-  end
-
-  describe '#search' do
-    it 'searches the vocabulary'
   end
 end

--- a/spec/qa/ldf/authority_spec.rb
+++ b/spec/qa/ldf/authority_spec.rb
@@ -28,17 +28,47 @@ describe Qa::LDF::Authority do
     it 'enumerates the vocabulary'
   end
 
-  describe '#find' do
-    it 'returns a JSON-like hash' do
-      expect(authority.find(subject_uri)).to be_a Hash
+  describe '#client' do
+    it 'defaults to an instance of DEFAULT_CLIENT' do
+      expect(described_class.new.client)
+        .to be_a described_class::DEFAULT_CLIENT
     end
 
-    it 'includes an id' do
-      expect(authority.find(subject_uri)[:id]).to eq subject_uri
+    it 'sets to other instances' do
+      client = described_class::DEFAULT_CLIENT.new
+
+      expect { authority.client = client }
+        .to change { authority.client }
+        .to equal client
+    end
+  end
+
+  describe '#dataset' do
+    it 'defaults an empty string symbol' do
+      expect(described_class.new.dataset).to eq :''
     end
 
-    it 'includes a label' do
-      expect(authority.find(subject_uri)[:label]).to eq label
+    it 'sets to other symbols' do
+      dataset_name = :lcsh
+
+      expect { authority.dataset = dataset_name }
+        .to change { authority.dataset }
+        .to eq dataset_name
+    end
+  end
+
+  describe '#mapper' do
+    it 'defaults to an instance of DEFAULT_MAPPER' do
+      expect(described_class.new.mapper)
+        .to be_a described_class::DEFAULT_MAPPER
+    end
+
+    it 'sets to other instances' do
+      mapper = described_class::DEFAULT_MAPPER.new
+
+      expect { authority.mapper = mapper }
+        .to change { authority.mapper }
+        .to equal mapper
     end
   end
 

--- a/spec/qa/ldf/client_spec.rb
+++ b/spec/qa/ldf/client_spec.rb
@@ -9,6 +9,8 @@ describe Qa::LDF::Client do
   let(:graph_stub) { RDF::Graph.new << [RDF::URI(uri), RDF.type, RDF.Property] }
 
   before do
+    # stub the external request, this behavior is owned by the server,
+    # we just allow it to make the request
     stub_request(:get, uri)
       .to_return(status:  200,
                  body:    graph_stub.dump(:ntriples),

--- a/spec/qa/ldf/empty_search_service_spec.rb
+++ b/spec/qa/ldf/empty_search_service_spec.rb
@@ -1,0 +1,17 @@
+# coding: utf-8
+require 'spec_helper'
+require 'qa/ldf/empty_search_service'
+
+describe Qa::LDF::EmptySearchService do
+  it_behaves_like 'an ldf search service'
+
+  subject(:search_service) { described_class.new }
+
+  describe '#search' do
+    it 'responds empty to arbitrary queries' do
+      ['-NonSensE\ !QUERY', 'Bărăganul (Romania)'].each do |query|
+        expect(search_service.search(query)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'pry' unless ENV['CI']
 require 'webmock/rspec'
 
 require 'qa/ldf'
+require 'qa/ldf/spec'
 
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 

--- a/spec/support/fake_client.rb
+++ b/spec/support/fake_client.rb
@@ -12,11 +12,13 @@ class FakeClient
     yield self if block_given?
   end
 
-  def get(uri:)
+  def get(uri:, dataset: :'')
     graph ||= RDF::Graph.new
+    # Use dataset just to satisfy rubocop.
+    # Is there a better config setting for this; exclude this cop from fakes?
     graph =
       graph.dup <<
-      [RDF::URI(uri), RDF::Vocab::SKOS.prefLabel, label || 'moomin']
+      [RDF::URI(uri), RDF::Vocab::SKOS.prefLabel, label || "#{dataset}: moomin"]
     graph
   end
 end

--- a/spec/support/fake_search_service.rb
+++ b/spec/support/fake_search_service.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+##
+# A fake version of `Qa::LDF::SearchService`.
+#
+# Configure with a hash of queries and responses to provide behavior.
+#
+# @example
+#   service = FakeSearchService.new do |service|
+#     service.queries['a query'] =
+#       [{ id: 'http://example.com/an_id', key: 'value' }]
+#   end
+#
+#   service.query('a query')
+#   # => [{ id: 'http://example.com/an_id', key: 'value' }]
+#
+class FakeSearchService
+  attr_accessor :queries
+
+  def initialize
+    @queries = {}
+    yield self if block_given?
+  end
+
+  def search(query)
+    queries[query] || {}
+  end
+end
+
+describe FakeSearchService do
+  subject(:search_service) do
+    described_class.new { |service| service.queries = searches }
+  end
+
+  subject(:searches) do
+    { 'a fake query' => [{ id: 'http://example.com/an_id', key: 'value' }] }
+  end
+
+  it_behaves_like 'an ldf search service'
+end

--- a/spec/support/shared_examples/ld_cache_client.rb
+++ b/spec/support/shared_examples/ld_cache_client.rb
@@ -6,17 +6,17 @@ shared_examples 'an ld cache client' do
       defined?(client)
   end
 
+  define :be_a_graph_with_subject do |expected|
+    match do |actual|
+      expect(actual).to respond_to :each_statement
+      expect(actual).to respond_to :query
+      expect(actual).to have_subject RDF::URI(expected)
+    end
+  end
+
   describe '#get' do
-    it 'returns an RDF::Enumerable' do
-      expect(client.get(uri: uri)).to respond_to :each_statement
-    end
-
-    it 'returns an RDF::Queryable' do
-      expect(client.get(uri: uri)).to respond_to :query
-    end
-
     it 'gives a graph with the subject' do
-      expect(client.get(uri: uri)).to have_subject RDF::URI(uri)
+      expect(client.get(uri: uri)).to be_a_graph_with_subject RDF::URI(uri)
     end
   end
 end

--- a/spec/support/shared_examples/ld_cache_client.rb
+++ b/spec/support/shared_examples/ld_cache_client.rb
@@ -18,5 +18,18 @@ shared_examples 'an ld cache client' do
     it 'gives a graph with the subject' do
       expect(client.get(uri: uri)).to be_a_graph_with_subject RDF::URI(uri)
     end
+
+    it 'adds to the root dataset'
+
+    context 'when passing a named dataset' do
+      let(:dataset) { 'viaf' }
+
+      it 'gives a graph with the subject' do
+        expect(client.get(uri: uri, dataset: dataset))
+          .to be_a_graph_with_subject RDF::URI(uri)
+      end
+
+      it 'adds to the named dataset'
+    end
   end
 end


### PR DESCRIPTION
Adds support for LCNames, a custom authority with a default dataset
name. We use the existing search logic that ships with QA. To support
this we add a search service interface and test compliance for the
existing Qa LOC support.

Makes tests for `LDF::Authority` sharable by making them shared examples
and moving them to `lib/qa/ldf/spec`.