### PR TITLE
Alias authority name to `Qa::Authorities` namespace

### DIFF
--- a/lib/qa/ldf/authorities/lc_names.rb
+++ b/lib/qa/ldf/authorities/lc_names.rb
@@ -20,4 +20,12 @@ module Qa
       end
     end
   end
+
+  ##
+  # Alias to hack Qa's namespaced authority logic.
+  #
+  # @see https://github.com/projecthydra-labs/questioning_authority/issues/137
+  module Authorities
+    Lcnames = LDF::LCNames
+  end
 end

--- a/lib/qa/ldf/spec/authority.rb
+++ b/lib/qa/ldf/spec/authority.rb
@@ -18,6 +18,13 @@ shared_examples 'an ldf authority' do
     end
   end
 
+  it 'is aliased to Qa::Authorities' do
+    unless described_class.eql?(Qa::LDF::Authority)
+      name = described_class.to_s.split('::').last.downcase.camelize
+      expect("Qa::Authorities::#{name}".constantize).to eql described_class
+    end
+  end
+
   describe '#all' do
     it 'is enumerable' do
       expect(authority.all).to respond_to :each


### PR DESCRIPTION
Authority registration is a hard coded constantize within this namespace. Pending work on a registry, this aliases `Qa::LDF::Authority` classes to the namespace to expose them to Questioning Authority.

See: https://github.com/projecthydra-labs/questioning_authority/issues/137