### PR TITLE
Add a base model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,4 @@ RSpec/FilePath:
     - 'spec/contracts/**/*'
     - 'spec/support/**/*'
     - 'spec/qa/ldf/authorities/**/*'
+    - 'spec/qa/ldf/models/**/*'

--- a/lib/qa/ldf.rb
+++ b/lib/qa/ldf.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 require 'qa/ldf/version'
 
+require 'qa/ldf/configuration'
 require 'qa/ldf/client'
 require 'qa/ldf/json_mapper'
-require 'qa/ldf/configuration'
+require 'qa/ldf/model'
 
 require 'qa/ldf/authority'
 require 'qa/ldf/authorities'

--- a/lib/qa/ldf/model.rb
+++ b/lib/qa/ldf/model.rb
@@ -1,0 +1,49 @@
+require 'active_triples'
+
+module Qa
+  module LDF
+    ##
+    # A base model for validatable authority values.
+    class Model
+      include ActiveTriples::RDFSource
+
+      class << self
+        ##
+        # Builds a model from the graph.
+        #
+        # @param graph [RDF::Graph]
+        #
+        # @return [Qa::LDF::Model] the built model
+        def from_graph(uri:, graph:)
+          new(uri) << graph
+        end
+
+        ##
+        # Builds a model from a QA result hash.
+        #
+        # @example
+        #   model =
+        #     Qa::LDF::Model.from_qa_result(id:    'http://example.com/moomin',
+        #                                   label: 'Moomin'
+        #   model.to_uri    # => #<RDF::URI:0x... URI:http://example.com/moomin>
+        #   model.rdf_label # => ['Moomin']
+        #
+        #
+        # @param qa_result [Hash<Symbol, String>]
+        #
+        # @return [Qa::LDF::Model] the built model
+        #
+        # @todo Make ActiveTriples::RDFSource#default_labels public or
+        #   protected.
+        def from_qa_result(qa_result:)
+          qa_result.dup
+          model = new(qa_result.delete(:id))
+          model.set_value(model.send(:default_labels).first,
+                          qa_result.delete(:label))
+
+          model
+        end
+      end
+    end
+  end
+end

--- a/lib/qa/ldf/spec.rb
+++ b/lib/qa/ldf/spec.rb
@@ -1,2 +1,3 @@
 require 'qa/ldf/spec/authority'
+require 'qa/ldf/spec/model'
 require 'qa/ldf/spec/search_service'

--- a/lib/qa/ldf/spec/model.rb
+++ b/lib/qa/ldf/spec/model.rb
@@ -1,0 +1,9 @@
+shared_examples 'an ldf model' do
+  before do
+    unless defined?(model)
+      raise ArgumentError,
+            "#{model} must be defined with `let(:model)` before " \
+            'using Qa::LDF::Model shared examples.'
+    end
+  end
+end

--- a/spec/qa/ldf/model_spec.rb
+++ b/spec/qa/ldf/model_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Qa::LDF::Model do
+  define :be_term do |expected|
+    match { |actual| expect(actual.to_term).to eq expected }
+  end
+
+  let(:id)    { 'http://example.com/authority/moomin' }
+  let(:label) { 'moomin' }
+
+  describe '.from_graph' do
+    let(:graph) do
+      graph = RDF::Graph.new
+      graph.insert(*statements)
+      graph
+    end
+
+    let(:statements) do
+      [RDF::Statement(RDF::URI(id),  RDF::Vocab::SKOS.prefLabel, label),
+       RDF::Statement(RDF::URI(id),  RDF::Vocab::DC.title, 'Moomin Papa'),
+       RDF::Statement(RDF::Node.new, RDF::Vocab::DC.title, 'Moomin Papa')]
+    end
+
+    it 'builds a model with the id as uri' do
+      expect(described_class.from_graph(uri: id, graph: graph))
+        .to be_term RDF::URI(id)
+    end
+
+    it 'builds a model with the label as label' do
+      expect(described_class.from_graph(uri: id, graph: graph))
+        .to have_attributes rdf_label: a_collection_containing_exactly(label)
+    end
+
+    it 'contains passed graph' do
+      expect(described_class.from_graph(uri: id, graph: graph).statements)
+        .to include(*statements)
+    end
+  end
+
+  describe '.from_qa_result' do
+    let(:json_hash) { { id: id, label: label, papa: 'moomin papa' } }
+
+    it 'builds a model with the id as uri' do
+      expect(described_class.from_qa_result(qa_result: json_hash))
+        .to be_term RDF::URI(id)
+    end
+
+    it 'builds a model with the label as label' do
+      expect(described_class.from_qa_result(qa_result: json_hash))
+        .to have_attributes rdf_label: a_collection_containing_exactly(label)
+    end
+  end
+end

--- a/spec/support/shared_examples/model.rb
+++ b/spec/support/shared_examples/model.rb
@@ -1,0 +1,2 @@
+shared_examples 'an ldf model' do
+end


### PR DESCRIPTION
Create a basic model that knows about its label and uri. Add builders from QA json-hashes and RDF graphs.