### PR TITLE
Use released version of QA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,6 @@ end
 
 gem 'pry' unless ENV['CI']
 
-# develop on qa master
-gem 'qa', github: 'projecthydra-labs/questioning_authority', branch: 'master'
-
 gem 'ld_cache_fragment',
     github: 'ActiveTriples/linked-data-fragments',
     branch: 'feature/multi-dataset'


### PR DESCRIPTION
We were developing on `master` but at this point we can commit to supporting `qa` 0.11.x.